### PR TITLE
Remove landing toast notification

### DIFF
--- a/px.js
+++ b/px.js
@@ -1,7 +1,4 @@
         document.addEventListener('DOMContentLoaded', function() {
-            if (!isMobileDevice()) {
-                showToast('如需获取分享链接，请关闭<code>沉浸式翻译</code>插件<br>否则会引起画面形变');
-            }
             fetchExchangeRates();
         });
 


### PR DESCRIPTION
## Summary
- remove the notification toast that appeared automatically on page load

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cac2a8ae9883258a3c7bd2007dcb25