### PR TITLE
refine markdown share content

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
                     <button type="button" class="btn btn-primary mr-1" onclick="calculateRemainingValue()">计算剩余价值</button>
                 </div>
                 <div class="col-auto">
-                    <button type="button" class="btn btn-primary" onclick="takeScreenshot()">获取分享链接</button>
+                    <button type="button" class="btn btn-primary" onclick="shareMarkdown()">复制分享内容</button>
                 </div>
             </div>
         </form>
@@ -150,7 +150,6 @@
     <script src="jquery-3.5.1.slim.min.js"></script>
     <script src="popper.min.js"></script>
     <script src="bootstrap.min.js"></script>
-    <script src="html2canvas.min.js"></script>
-    <script src="px.js"></script>     
+    <script src="px.js"></script>
 </body>
 </html>

--- a/px.js
+++ b/px.js
@@ -26,52 +26,98 @@
         }
 
         function takeScreenshot() {
-            const targetElement = document.querySelector('.container');
-            const uploadButton = document.querySelector('button[onclick="takeScreenshot()"]');
-            const loadingDiv = document.getElementById('loading');
+            const resultSection = document.querySelector('.result');
             const screenshotResult = document.getElementById('screenshotResult');
+            const loadingDiv = document.getElementById('loading');
+
+            if (!resultSection || resultSection.style.display === 'none') {
+                showToast('请先完成计算再分享');
+                return;
+            }
+
+            const dataDate = document.getElementById('dataDate').value || '';
+            const purchasePrice = document.getElementById('resultPurchasePriceCNY').textContent || '0.00';
+            const remainingValue = document.getElementById('resultRemainingValueCNY').textContent || '0.00';
+            const remainingDays = document.getElementById('resultRemainingDays').textContent || '0';
+            const remainingMonths = document.getElementById('resultRemainingMonths').textContent || '0';
+            const remainingDay = document.getElementById('resultRemainingDay').textContent || '0';
+            const tradePrice = document.getElementById('resultTradePriceCNY').textContent || '0.00';
+            const premium = document.getElementById('resultPremiumCNY').textContent || '0.00';
+            const premiumPercent = document.getElementById('resultPremiumPercent').textContent || '0%';
+            const advice = document.getElementById('resultAdvice').textContent || '暂无建议';
+
+            const purchaseCurrency = document.getElementById('purchaseCurrency').value || 'CNY';
+            const tradeCurrency = document.getElementById('tradeCurrency').value || 'CNY';
+            const purchaseInputValue = parseFloat(document.getElementById('purchasePrice').value);
+            const tradeInputValue = parseFloat(document.getElementById('tradePrice').value);
+            const purchaseRateValue = parseFloat(document.getElementById('exchangeRate').value);
+            const tradeRateValue = parseFloat(document.getElementById('tradeExchangeRate').value);
+
+            const formatAmount = (amount, currency) => {
+                if (!Number.isFinite(amount)) {
+                    return currency === 'CNY' ? '￥NaN' : `NaN ${currency}`;
+                }
+                const formatted = amount.toFixed(2);
+                return currency === 'CNY' ? `￥${formatted}` : `${formatted} ${currency}`;
+            };
+
+            const formatRate = (rate, currency) => {
+                if (!Number.isFinite(rate)) {
+                    return 'NaN';
+                }
+                return `1 ${currency} = ${rate.toFixed(4)} CNY`;
+            };
+
+            const generatedAt = new Date().toLocaleString('zh-CN', { hour12: false });
+
+            const markdownLines = [];
+            markdownLines.push('# 剩余价值计算结果');
+            markdownLines.push(`> 汇率数据日期：${dataDate || '暂无数据'}`);
+            markdownLines.push('');
+            markdownLines.push('| 项目 | 数值 |');
+            markdownLines.push('| --- | --- |');
+            markdownLines.push(`| 续费货币 | ${purchaseCurrency} |`);
+            markdownLines.push(`| 续费金额（${purchaseCurrency}） | ${formatAmount(purchaseInputValue, purchaseCurrency)} |`);
+            markdownLines.push(`| 汇率（${purchaseCurrency}→CNY） | ${formatRate(purchaseRateValue, purchaseCurrency)} |`);
+            markdownLines.push(`| 续费金额（CNY） | ￥${purchasePrice} |`);
+            markdownLines.push(`| 交易货币 | ${tradeCurrency} |`);
+            markdownLines.push(`| 交易金额（${tradeCurrency}） | ${formatAmount(tradeInputValue, tradeCurrency)} |`);
+            markdownLines.push(`| 汇率（${tradeCurrency}→CNY） | ${formatRate(tradeRateValue, tradeCurrency)} |`);
+            markdownLines.push(`| 交易金额（CNY） | ￥${tradePrice} |`);
+            markdownLines.push(`| 剩余价值（CNY） | ￥${remainingValue} |`);
+            markdownLines.push(`| 剩余天数 | ${remainingDays} 天 (${remainingMonths} 个月余 ${remainingDay} 天) |`);
+            markdownLines.push(`| 溢价金额（CNY） | ￥${premium} |`);
+            markdownLines.push(`| 溢价幅度 | ${premiumPercent} |`);
+            markdownLines.push(`| 购买建议 | ${advice || '暂无建议'} |`);
+            markdownLines.push('');
+            markdownLines.push(`生成于：${generatedAt}`);
+
+            const markdownContent = markdownLines.join('\n');
 
             loadingDiv.style.display = 'none';
-            screenshotResult.style.display = 'none';
+            screenshotResult.style.display = 'block';
+            screenshotResult.innerHTML = `Markdown 分享内容：<pre><code class="language-markdown">${escapeHtml(markdownContent)}</code></pre>`;
 
-            html2canvas(targetElement).then(canvas => {
-                loadingDiv.style.display = 'block';
-                screenshotResult.style.display = 'block';
-
-                canvas.toBlob(blob => {
-                    const formData = new FormData();
-                    formData.append('file', blob, 'mjj.webp');
-
-                    fetch('https://skyimg.de/api/upload', {
-                        method: 'POST',
-                        body: formData
-                    })
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data && Array.isArray(data) && data[0].url) {
-                            const imageUrl = data[0].url;
-
-                            document.getElementById('screenshotResult').innerHTML =
-                                `图片分享链接：<a href="${imageUrl}" target="_blank">点击查看</a>`;
-
-                            navigator.clipboard.writeText(imageUrl).then(() => {
-                                showToast('图片分享链接已复制到剪切板');
-                            }, err => {
-                                showToast('复制到剪切板失败');
-                            });
-                        } else {
-                            document.getElementById('screenshotResult').textContent = '上传成功但未获取到 URL！';
-                        }
-                        loadingDiv.style.display = 'none';
-                        uploadButton.style.visibility = 'visible';
-                    })
-                    .catch(error => {
-                        document.getElementById('screenshotResult').textContent = '上传失败！';
-                        console.error('Error:', error);
-                        loadingDiv.style.display = 'none';
-                    });
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(markdownContent).then(() => {
+                    showToast('分享内容已复制到剪切板');
+                }).catch(() => {
+                    showToast('自动复制失败，请手动复制下方内容');
                 });
-            });
+            } else {
+                showToast('当前环境不支持自动复制，请手动复制下方内容');
+            }
+        }
+
+        function escapeHtml(text) {
+            const map = {
+                "&": "&amp;",
+                "<": "&lt;",
+                ">": "&gt;",
+                "\"": "&quot;",
+                "'": "&#39;"
+            };
+            return text.replace(/[&<>"']/g, m => map[m]);
         }
 
         async function fetchExchangeRates() {

--- a/px.js
+++ b/px.js
@@ -1,6 +1,6 @@
         document.addEventListener('DOMContentLoaded', function() {
             if (!isMobileDevice()) {
-                showToast('如需获取分享链接，请关闭<code>沉浸式翻译</code>插件<br>否则会引起画面形变');
+                showToast('如需复制分享内容，请关闭<code>沉浸式翻译</code>插件<br>否则可能会影响页面显示');
             }
             fetchExchangeRates();
         });
@@ -25,7 +25,7 @@
             }, 6000);
         }
 
-        function takeScreenshot() {
+        function shareMarkdown() {
             const resultSection = document.querySelector('.result');
             const screenshotResult = document.getElementById('screenshotResult');
             const loadingDiv = document.getElementById('loading');


### PR DESCRIPTION
## Summary
- remove the fenced code block from the sharing output and generate the formatted Markdown snippet with a blank line before the table
- include currency, original amount, and exchange-rate rows in the shared table for easier reading, with helpers that keep NaN placeholders when data is missing
- adjust the clipboard toast message to reflect the new sharing format

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cabee7f8708325a036c10423b39505